### PR TITLE
feat: add Nix flake for charmbracelet/mods CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
-# flakes
-A collection of hopefully useful nix flakes.
+# Flakes Collection
+
+A collection of useful Nix flakes providing packaged software and tools.
+
+## Available Flakes
+
+| Flake | Description | Quick Usage |
+|-------|-------------|-------------|
+| [🤖 mods](./mods/) | AI on the command line | `nix run github:ck3mp3r/flakes?dir=mods` |
+| [🌳 topiary-nu](./topiary-nu/) | Nushell formatting with tree-sitter | `nix run github:ck3mp3r/flakes?dir=topiary-nu` |
+
+## Quick Start
+
+### Run any flake directly
+```bash
+nix run github:ck3mp3r/flakes?dir=<flake-name>
+```
+
+### Install to your profile
+```bash
+nix profile install github:ck3mp3r/flakes?dir=<flake-name>
+```
+
+### Use in your flake.nix
+```nix
+{
+  inputs = {
+    <flake-name>.url = "github:ck3mp3r/flakes?dir=<flake-name>";
+  };
+}
+```
+
+Replace `<flake-name>` with either `mods` or `topiary-nu`.
+
+## Detailed Documentation
+
+Each flake has its own detailed README with usage examples, configuration instructions, and build information:
+
+- **[mods/README.md](./mods/README.md)** - Complete documentation for the AI CLI tool
+- **[topiary-nu/README.md](./topiary-nu/README.md)** - Complete documentation for Nushell formatting
+
+## Repository Structure
+
+```
+├── mods/           # AI CLI tool flake
+│   ├── flake.nix
+│   ├── flake.lock
+│   └── README.md
+├── topiary-nu/     # Nushell formatter flake  
+│   ├── flake.nix
+│   ├── flake.lock
+│   └── README.md
+└── README.md       # This file
+```
+
+## Contributing
+
+Feel free to submit PRs for additional useful flakes or improvements to existing ones. Each flake should:
+
+- Be self-contained in its own directory
+- Include comprehensive documentation in its README
+- Follow Nix best practices
+- Include proper licensing information
+
+## License
+
+This repository is licensed under the MIT License. Individual packages may have their own licenses - see their respective documentation for details.

--- a/mods/README.md
+++ b/mods/README.md
@@ -1,0 +1,66 @@
+# mods
+
+A Nix flake for the [charmbracelet/mods](https://github.com/charmbracelet/mods) CLI tool - AI on the command line.
+
+## Description
+
+This flake packages the mods CLI tool, which allows you to interact with AI models directly from your terminal. It supports various AI providers and can be used for code generation, text processing, and general AI assistance.
+
+## Features
+
+- Built from the latest upstream source
+- Go module with proper dependency management
+- Includes version information in binary
+- MIT licensed
+- Cross-platform support (Linux, macOS, Windows)
+
+## Usage
+
+### Run directly
+```bash
+nix run github:ck3mp3r/flakes?dir=mods
+```
+
+### Install to profile
+```bash
+nix profile install github:ck3mp3r/flakes?dir=mods
+```
+
+### Use in flake.nix
+```nix
+{
+  inputs = {
+    mods.url = "github:ck3mp3r/flakes?dir=mods";
+  };
+  
+  outputs = { self, nixpkgs, mods, ... }: {
+    # Use mods.packages.${system}.default
+  };
+}
+```
+
+### Local development
+```bash
+# From this directory
+nix run .
+
+# Build locally
+nix build .
+```
+
+## Configuration
+
+After installation, you'll need to configure mods with your AI provider API keys. See the [upstream documentation](https://github.com/charmbracelet/mods#configuration) for details.
+
+## Upstream
+
+- **Source**: [charmbracelet/mods](https://github.com/charmbracelet/mods)
+- **License**: MIT
+- **Version**: Built from latest commit (unstable)
+
+## Building
+
+This flake uses `buildGoModule` with:
+- `vendorHash = null` and `proxyVendor = true` for dependency management
+- Version information embedded via ldflags
+- Automatic dependency resolution from go.mod/go.sum

--- a/mods/flake.lock
+++ b/mods/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mods-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750075469,
+        "narHash": "sha256-dCNVDf05wRvs84eVChMGtRtg5fOWhiz1I/L8F/9Rw/Q=",
+        "owner": "charmbracelet",
+        "repo": "mods",
+        "rev": "de347f6c78361985317b1232816735193a31ba3e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "charmbracelet",
+        "repo": "mods",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1750268545,
+        "narHash": "sha256-9CBxih8ERwi4lHM6eUtRnjP4O0/czVPfSYUxdlRERhg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "106daa382b3a5625c9698cbff9f13bbee8c62dbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "mods-src": "mods-src",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/topiary-nu/README.md
+++ b/topiary-nu/README.md
@@ -1,0 +1,88 @@
+# topiary-nu
+
+A Nix flake providing Topiary formatting functionality for Nushell with tree-sitter-nu grammar support.
+
+## Description
+
+This flake packages a custom build of Topiary language configuration and tree-sitter grammar specifically for Nushell (`.nu`) files. It enables proper syntax-aware formatting of Nushell scripts.
+
+## Features
+
+- Custom tree-sitter grammar for Nushell syntax
+- Topiary language configuration for `.nu` files
+- Built from [blindFS/topiary-nushell](https://github.com/blindFS/topiary-nushell)
+- Includes compiled tree-sitter-nu parser
+- ABI version 14 compatibility
+
+## Usage
+
+### Run directly
+```bash
+nix run github:ck3mp3r/flakes?dir=topiary-nu
+```
+
+### Install to profile
+```bash
+nix profile install github:ck3mp3r/flakes?dir=topiary-nu
+```
+
+### Use in flake.nix
+```nix
+{
+  inputs = {
+    topiary-nu.url = "github:ck3mp3r/flakes?dir=topiary-nu";
+  };
+  
+  outputs = { self, nixpkgs, topiary-nu, ... }: {
+    # Use topiary-nu.packages.${system}.default
+  };
+}
+```
+
+### Local development
+```bash
+# From this directory
+nix run .
+
+# Build locally
+nix build .
+```
+
+## Components
+
+This flake builds two main components:
+
+1. **tree-sitter-nu**: Compiled tree-sitter grammar for Nushell
+   - Generated from [nushell/tree-sitter-nu](https://github.com/nushell/tree-sitter-nu)
+   - Compiled as shared library (`tree_sitter_nu.so`)
+   - ABI version 14
+
+2. **topiary-nu**: Language configuration for Topiary
+   - Based on [blindFS/topiary-nushell](https://github.com/blindFS/topiary-nushell)
+   - Includes language definitions and formatting rules
+   - Configured for `.nu` file extensions
+
+## Usage with Topiary
+
+Once installed, you can use this with the main Topiary formatter:
+
+```bash
+# Format a Nushell file
+topiary format --language nu script.nu
+
+# Check formatting
+topiary check --language nu script.nu
+```
+
+## Upstream Sources
+
+- **Tree-sitter grammar**: [nushell/tree-sitter-nu](https://github.com/nushell/tree-sitter-nu)
+- **Topiary configuration**: [blindFS/topiary-nushell](https://github.com/blindFS/topiary-nushell)
+- **Topiary formatter**: [tweag/topiary](https://github.com/tweag/topiary)
+
+## Building
+
+This flake uses custom derivations to:
+1. Compile the tree-sitter-nu grammar with proper ABI version
+2. Package the language configuration files
+3. Link the compiled grammar to the configuration


### PR DESCRIPTION
- Add flake.nix with Go module build configuration for mods package
- Configure nixpkgs input with unfree packages enabled and Go proxy settings
- Create overlay to expose mods package in final package set
- Lock dependencies with flake-utils, nixpkgs, and mods source inputs