### PR TITLE
feat: add Kubernetes utilities flake bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A collection of useful Nix flakes providing packaged software and tools.
 
 | Flake | Description | Quick Usage |
 |-------|-------------|-------------|
+| [☸️ k8s-utils](./k8s-utils/) | Comprehensive Kubernetes CLI tools bundle | `nix shell github:ck3mp3r/flakes?dir=kubernetes` |
 | [🤖 mods](./mods/) | AI on the command line | `nix run github:ck3mp3r/flakes?dir=mods` |
 | [🌳 topiary-nu](./topiary-nu/) | Nushell formatting with tree-sitter | `nix run github:ck3mp3r/flakes?dir=topiary-nu` |
 
@@ -30,18 +31,23 @@ nix profile install github:ck3mp3r/flakes?dir=<flake-name>
 }
 ```
 
-Replace `<flake-name>` with either `mods` or `topiary-nu`.
+Replace `<flake-name>` with `kubernetes`, `mods`, or `topiary-nu`.
 
 ## Detailed Documentation
 
 Each flake has its own detailed README with usage examples, configuration instructions, and build information:
 
+- **[k8s-utils/README.md](./k8s-utils/README.md)** - Complete documentation for Kubernetes CLI tools bundle
 - **[mods/README.md](./mods/README.md)** - Complete documentation for the AI CLI tool
 - **[topiary-nu/README.md](./topiary-nu/README.md)** - Complete documentation for Nushell formatting
 
 ## Repository Structure
 
 ```
+├── k8s-utils/     # Kubernetes CLI tools bundle flake
+│   ├── flake.nix
+│   ├── flake.lock
+│   └── README.md
 ├── mods/           # AI CLI tool flake
 │   ├── flake.nix
 │   ├── flake.lock

--- a/k8s-utils/README.md
+++ b/k8s-utils/README.md
@@ -1,0 +1,102 @@
+# Kubernetes Utilities Flake
+
+This flake provides a comprehensive bundle of Kubernetes CLI tools and utilities for development, operations, and management tasks.
+
+## What's Included
+
+This flake bundles the following Kubernetes-related applications:
+
+### Core Tools
+- **kubectl** - The main Kubernetes command-line tool
+- **kubectx** - Fast way to switch between Kubernetes clusters
+- **kustomize** - Kubernetes configuration management tool
+- **helm** (kubernetes-helm) - The Kubernetes package manager
+
+### Development & Testing
+- **kind** - Kubernetes in Docker - local Kubernetes clusters
+- **colima** - Container runtime for macOS (Darwin only)
+
+### Monitoring & Debugging
+- **k9s** - Terminal-based UI for Kubernetes clusters
+- **stern** - Multi-pod and container log tailing
+
+## Usage
+
+### Quick Run (Ephemeral Shell)
+
+For temporary use without installing, you can enter an ephemeral shell with all tools available:
+
+```bash
+# Enter a shell with all k8s tools available
+nix shell github:ck3mp3r/flakes?dir=k8s-utils
+
+# Or use the shorter syntax
+nix shell github:ck3mp3r/flakes#k8s-utils
+```
+
+This gives you immediate access to all bundled tools without modifying your system. When you exit the shell, the tools are no longer available.
+
+### Install the entire bundle
+
+```bash
+# Install all tools permanently
+nix profile install github:ck3mp3r/flakes?dir=k8s-utils
+```
+
+### Use in your own flake
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    k8s-utils.url = "github:ck3mp3r/flakes?kubernetes";
+  };
+
+  outputs = { self, nixpkgs, k8s-utils, ... }: {
+    # Use the overlay
+    pkgs = import nixpkgs {
+      system = "x86_64-linux";
+      overlays = [ k8s-utils.overlays.default ];
+    };
+    
+    # Or reference the package directly
+    devShells.default = nixpkgs.mkShell {
+      buildInputs = [ k8s-utils.packages.x86_64-linux.default ];
+    };
+  };
+}
+```
+
+## Platform Support
+
+- **Linux** (x86_64, aarch64)
+- **macOS** (x86_64, aarch64) - includes macOS-specific tools like colima
+
+## Quick Start
+
+Once installed, you'll have access to all the bundled tools. Here are some common workflows:
+
+```bash
+# Switch between clusters
+kubectx my-cluster
+
+# Switch between namespaces
+kubens my-namespace
+
+# Monitor your cluster with a TUI
+k9s
+
+# View logs from multiple pods
+stern my-app
+
+# Deploy with Helm
+helm install my-release ./my-chart
+
+# Apply Kustomize configurations
+kustomize build ./overlays/production | kubectl apply -f -
+```
+
+## Contributing
+
+This flake is part of the [ck3mp3r/flakes](https://github.com/ck3mp3r/flakes) repository. Please see the main repository for contribution guidelines.
+

--- a/k8s-utils/flake.lock
+++ b/k8s-utils/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1750539538,
+        "narHash": "sha256-JnQ9ZPPSJ/E8CJJJkVWbjpWLG4wgGFQbO09G20V7ua8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "951c83d8b4c554e83880a98a42e0e663be1d95a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/k8s-utils/flake.nix
+++ b/k8s-utils/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "This brings in clis and utilities related to kubernetes.";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+          config = {allowUnfree = true;};
+        };
+
+        # Bundle of Kubernetes-related applications
+        k8s-bundle = pkgs.buildEnv {
+          name = "k8s-utils";
+          paths = with pkgs;
+            [
+              k9s
+              kind
+              kubectl
+              kubectx
+              kubernetes-helm
+              kustomize
+              stern
+            ]
+            ++ lib.optionals stdenv.isDarwin [colima];
+          pathsToLink = ["/bin" "/share"];
+        };
+      in {
+        packages.default = k8s-bundle;
+      }
+    )
+    // {
+      overlays.default = final: prev: {
+        k8s-utils = self.packages.${final.system}.default;
+      };
+    };
+}


### PR DESCRIPTION
- Add comprehensive k8s-utils flake with kubectl, helm, k9s, and development tools
- Include platform-specific packages with Darwin-only colima support
- Provide buildEnv bundle for unified installation of Kubernetes CLI toolchain
- Add flake overlay for integration into other Nix configurations