### PR TITLE
feat: add crush flake for AI coding TUI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A collection of useful Nix flakes providing packaged software and tools.
 |-------|-------------|-------------|
 | [☸️ k8s-utils](./k8s-utils/) | Comprehensive Kubernetes CLI tools bundle | `nix shell github:ck3mp3r/flakes?dir=k8s-utils` |
 | [🤖 mods](./mods/) | AI on the command line | `nix run github:ck3mp3r/flakes?dir=mods` |
+| [🪨 crush](./crush/) | Glamourous AI coding TUI agent | `nix run github:ck3mp3r/flakes?dir=crush` |
 | [🌳 topiary-nu](./topiary-nu/) | Nushell formatting with tree-sitter | `nix run github:ck3mp3r/flakes?dir=topiary-nu` |
 | [🧠 avante.nvim](./avante/) | AI-powered IDE features for Neovim | Neovim plugin |
 
@@ -32,7 +33,7 @@ nix profile install github:ck3mp3r/flakes?dir=<flake-name>
 }
 ```
 
-Replace `<flake-name>` with `kubernetes`, `mods`, or `topiary-nu`.
+Replace `<flake-name>` with `k8s-utils`, `mods`, `crush`, or `topiary-nu`.
 
 ## Contributing
 

--- a/crush/README.md
+++ b/crush/README.md
@@ -1,0 +1,67 @@
+# crush
+
+A Nix flake for the [charmbracelet/crush](https://github.com/charmbracelet/crush) TUI app — AI on the command line.
+
+## Description
+
+This flake packages the `crush` TUI (terminal user interface) application, enabling seamless usage of the glamourous AI coding agent directly from your terminal.
+
+## Features
+
+- Built from the latest upstream source
+- Go module with proper dependency management
+- Includes version information in the binary
+- MIT licensed (this flake)
+- Cross-platform support (Linux, macOS, Windows)
+
+## Usage
+
+### Run directly
+```bash
+nix run github:ck3mp3r/flakes?dir=crush
+```
+
+### Install to profile
+```bash
+nix profile install github:ck3mp3r/flakes?dir=crush
+```
+
+### Use in flake.nix
+```nix
+{
+  inputs = {
+    crush.url = "github:ck3mp3r/flakes?dir=crush";
+  };
+  
+  outputs = { self, nixpkgs, crush, ... }: {
+    # Use crush.packages.${system}.default
+  };
+}
+```
+
+### Local development
+```bash
+# From this directory
+nix run .
+
+# Build locally
+nix build .
+```
+
+## Configuration
+
+After installation, configure crush for your AI provider if required. See the [upstream documentation](https://github.com/charmbracelet/crush) for details.
+
+## Upstream
+
+- **Source**: [charmbracelet/crush](https://github.com/charmbracelet/crush)
+- **License**: MIT
+- **Version**: Built from latest commit (unstable)
+
+## Building
+
+This flake uses `buildGoModule` with:
+- `vendorHash = null` and `proxyVendor = true` for dependency management
+- Version information embedded via ldflags
+- Automatic dependency resolution from go.mod/go.sum
+

--- a/crush/flake.lock
+++ b/crush/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "crush-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1753976417,
+        "narHash": "sha256-ZcLT6DzOn2WcAJS4bhMR5vXgvvUiIrcajGPlipG1GJs=",
+        "owner": "charmbracelet",
+        "repo": "crush",
+        "rev": "713a7f72a08ce5742a0ce0fad1192ad35dd528c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "charmbracelet",
+        "repo": "crush",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1750268545,
+        "narHash": "sha256-9CBxih8ERwi4lHM6eUtRnjP4O0/czVPfSYUxdlRERhg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "106daa382b3a5625c9698cbff9f13bbee8c62dbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crush-src": "crush-src",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/crush/flake.nix
+++ b/crush/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "This flake wraps the charmbracelet/crush tui app.";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+    crush-src = {
+      url = "github:charmbracelet/crush";
+      flake = false;
+    };
+  };
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    crush-src,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+          config = {allowUnfree = true;};
+        };
+        crush = pkgs.buildGoModule rec {
+          pname = "crush";
+          version = "unstable-${pkgs.lib.substring 0 8 src.rev}";
+
+          src = crush-src;
+          vendorHash = null;
+          proxyVendor = true;
+
+          preBuild = ''
+            export GOPROXY=https://proxy.golang.org
+          '';
+          doCheck = false;
+          ldflags = [
+            "-s"
+            "-w"
+            "-X=main.Version=${version}"
+          ];
+
+          meta = with pkgs.lib; {
+            description = "AI on the command line";
+            homepage = "The glamourous AI coding agent for your favourite terminal 💘";
+            license = licenses.mit;
+          };
+        };
+      in {
+        packages.default = crush;
+      }
+    )
+    // {
+      overlays.default = final: prev: {
+        crush = self.packages.${final.system}.default;
+      };
+    };
+}


### PR DESCRIPTION
- Introduce new crush flake wrapping charmbracelet/crush TUI app
- Define flake.nix to build Go module with upstream source and version info
- Add flake.lock to pin dependencies for reproducible builds
- Provide documentation for usage, features, and configuration in crush/README.md
- Update root README to include crush in available flakes and usage instructions