### PR TITLE
feat(slidev): add Slidev presentation tool flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A collection of useful Nix flakes providing packaged software and tools.
 | [🌳 topiary-nu](./topiary-nu/) | Nushell formatting with tree-sitter | `nix run github:ck3mp3r/flakes?dir=topiary-nu` |
 | [🧠 avante.nvim](./avante/) | AI-powered IDE features for Neovim | Neovim plugin |
 | [🧰 rustix](./rustix/) | Reusable Nix library functions for Rust multiarch and artifact packaging | See [README](./rustix/README.md) |
+| [📊 slidev](./slidev/) | Presentation slides for developers | `nix run github:ck3mp3r/flakes?dir=slidev` |
 
 ## Quick Start
 
@@ -34,7 +35,7 @@ nix profile install github:ck3mp3r/flakes?dir=<flake-name>
 }
 ```
 
-Replace `<flake-name>` with `k8s-utils`, `mods`, `crush`, `topiary-nu`, or `rustix`.
+Replace `<flake-name>` with `k8s-utils`, `mods`, `crush`, `topiary-nu`, `rustix`, or `slidev`.
 
 ## Contributing
 

--- a/slidev/README.md
+++ b/slidev/README.md
@@ -1,0 +1,114 @@
+# Slidev Nix Flake
+
+This Nix flake packages [Slidev](https://sli.dev), a presentation slides tool for developers.
+
+## Usage
+
+### Install Slidev globally
+
+```bash
+# Install with nix profile
+nix profile install github:ck3mp3r/flakes?dir=slidev#slidev
+
+# Or run directly
+nix run github:ck3mp3r/flakes?dir=slidev#slidev -- --help
+```
+
+### Use in a development environment
+
+```bash
+# Enter a development shell with Slidev available
+nix develop github:ck3mp3r/flakes?dir=slidev#slidev
+```
+
+### Add to your system flake
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    slidev-flake.url = "github:ck3mp3r/flakes?dir=slidev";
+  };
+
+  outputs = { self, nixpkgs, slidev-flake }: {
+    # Your configuration here
+    environment.systemPackages = [
+      slidev-flake.packages.${system}.slidev
+    ];
+  };
+}
+```
+
+## Building locally
+
+```bash
+# Navigate to the slidev directory
+cd slidev
+
+# Build the package
+nix build .#slidev
+
+# Run the built package  
+./result/bin/slidev --help
+
+# Format the flake (uses Alejandra)
+nix fmt .
+```
+
+## Features
+
+- Uses GitHub source as flake input for reproducibility
+- Includes proper Node.js 20 runtime
+- Provides both CLI application and development shell
+- Follows Nix flake best practices
+
+## Requirements
+
+- Nix with flakes enabled
+- Node.js >=18.0.0 (provided by the flake)
+
+## Updating
+
+To update to the latest Slidev version:
+
+```bash
+nix flake update
+```
+
+This will update the `slidev-src` input to the latest commit from the Slidev repository.
+
+## Implementation
+
+This flake uses a pragmatic approach:
+
+1. **Source Input**: Uses the official Slidev GitHub repository as a flake input for version tracking
+2. **Runtime Approach**: Creates a wrapper that uses `npx @slidev/cli@latest` to ensure you always get the latest compatible version
+3. **No Complex Build**: Avoids the complexity of building the entire pnpm monorepo by delegating to npm's package manager
+
+## Testing
+
+To verify the installation works:
+
+```bash
+# Navigate to the slidev directory first
+cd slidev
+
+# Test version
+nix run .#slidev -- --version
+
+# Test help
+nix run .#slidev -- --help
+
+# Create a simple presentation
+mkdir test-presentation
+cd test-presentation
+echo "# Hello Slidev" > slides.md
+nix run ..#slidev
+```
+
+### Testing from outside the directory
+
+```bash
+# Test from anywhere using the full GitHub path
+nix run github:ck3mp3r/flakes?dir=slidev#slidev -- --version
+```

--- a/slidev/flake.lock
+++ b/slidev/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "slidev-src": "slidev-src"
+      }
+    },
+    "slidev-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755674334,
+        "narHash": "sha256-gK++nsueBgH4GkCOIOdkpHu9TNWCrX6tAsbQ7rbsW8M=",
+        "owner": "slidevjs",
+        "repo": "slidev",
+        "rev": "5637013f7a6230e9de921185a7381c9cff3f4f8c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "slidevjs",
+        "repo": "slidev",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/slidev/flake.nix
+++ b/slidev/flake.nix
@@ -1,0 +1,96 @@
+{
+  description = "Slidev - Presentation slides for developers";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    slidev-src = {
+      url = "github:slidevjs/slidev";
+      flake = false;
+    };
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    slidev-src,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      # Read package info from the CLI package
+      packageJson = builtins.fromJSON (builtins.readFile "${slidev-src}/packages/slidev/package.json");
+
+      slidev = pkgs.stdenv.mkDerivation {
+        pname = packageJson.name;
+        version = packageJson.version;
+
+        # No source needed since we use npx
+        dontUnpack = true;
+
+        nativeBuildInputs = with pkgs; [
+          nodejs_20
+          makeWrapper
+        ];
+
+        # Simple installation that uses npx
+        installPhase = ''
+          runHook preInstall
+
+          # Create the binary using makeWrapper
+          mkdir -p $out/bin
+          makeWrapper ${pkgs.nodejs_20}/bin/npx $out/bin/slidev \
+            --add-flags "--yes @slidev/cli@${packageJson.version}" \
+            --run "cd \$HOME"
+
+          runHook postInstall
+        '';
+
+        meta = with pkgs.lib; {
+          description = "Presentation slides for developers";
+          longDescription = ''
+            Slidev aims to provide the flexibility and interactivity for developers
+            to make their presentations even more interesting, expressive, and attractive
+            by using the tools and technologies they are already familiar with.
+          '';
+          homepage = "https://sli.dev";
+          license = licenses.mit;
+          maintainers = [];
+          platforms = platforms.all;
+          mainProgram = "slidev";
+        };
+      };
+    in {
+      packages = {
+        default = slidev;
+        inherit slidev;
+      };
+
+      apps = {
+        default = {
+          type = "app";
+          program = "${slidev}/bin/slidev";
+        };
+        slidev = {
+          type = "app";
+          program = "${slidev}/bin/slidev";
+        };
+      };
+
+      devShells.default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          nodejs_20
+          nodePackages.pnpm
+          slidev
+        ];
+
+        shellHook = ''
+          echo "Slidev development environment"
+          echo "Run 'slidev --help' to get started"
+        '';
+      };
+
+      formatter = pkgs.alejandra;
+    });
+}


### PR DESCRIPTION
Add Nix flake for Slidev, a presentation slides tool for developers. Uses pragmatic npx-based approach for fast builds and reliable operation.

Features:
- GitHub source input for version tracking
- Node.js 20 runtime support
- CLI application and development shell outputs
- Cross-platform compatibility