### PR TITLE
feat(slidev): standardize devShell to use numtide devshell with TOML …

### DIFF
--- a/slidev/devshell.toml
+++ b/slidev/devshell.toml
@@ -1,0 +1,36 @@
+name = "slidev"
+motd = """
+{202}🎭 Slidev Development Environment{reset}
+{14}Presentation slides for developers{reset}
+
+$(type -p menu &>/dev/null && menu)
+"""
+
+packages = [
+  "nodejs_20",
+  "nodePackages.pnpm"
+]
+
+[[commands]]
+name = "slidev-help"
+help = "Show Slidev help"
+command = "slidev --help"
+category = "presentation"
+
+[[commands]]
+name = "dev"
+help = "Start development server with browser"
+command = "slidev --open"
+category = "presentation"
+
+[[commands]]
+name = "build"
+help = "Build static presentation"
+command = "slidev build"
+category = "presentation"
+
+[[commands]]
+name = "export"
+help = "Export to PDF/PPTX/PNG"
+command = "slidev export"
+category = "presentation"

--- a/slidev/flake.lock
+++ b/slidev/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741473158,
+        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -36,6 +56,7 @@
     },
     "root": {
       "inputs": {
+        "devshell": "devshell",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "slidev-src": "slidev-src"


### PR DESCRIPTION
…config

- Add devshell input to flake with nixpkgs follows
- Replace mkShell with devshell.mkShell using TOML import
- Create devshell.toml with custom presentation commands
- Include nodejs_20, pnpm, and slidev package
- Add custom commands: dev, build, export, slidev-help
- Organize commands in presentation category with helpful descriptions