### PR TITLE
support nativeBuildInputs and merge with extraArgs

### DIFF
--- a/rustix/lib/rust/build.nix
+++ b/rustix/lib/rust/build.nix
@@ -21,6 +21,7 @@
           cargoLock
           ;
         buildInputs = extraArgs.buildInputs or [];
+        nativeBuildInputs = extraArgs.nativeBuildInputs or [];
       }
       // extraArgs);
 in

--- a/rustix/lib/rust/default.nix
+++ b/rustix/lib/rust/default.nix
@@ -1,12 +1,14 @@
 let
   buildPackages = {
     archiveAndHash ? false,
+    buildInputs ? [],
     cargoLock,
     cargoToml,
     extraArgs ? {},
     fenix,
     installData,
     linuxVariant ? "musl",
+    nativeBuildInputs ? [],
     nixpkgs,
     overlays,
     pkgs,
@@ -64,8 +66,13 @@ let
         name = target;
         value = let
           cross = crossPkgs target;
+          mergedExtraArgs = extraArgs // {
+            buildInputs = (extraArgs.buildInputs or []) ++ buildInputs;
+            nativeBuildInputs = (extraArgs.nativeBuildInputs or []) ++ nativeBuildInputs;
+          };
           plain = cross.callPackage ./build.nix {
-            inherit cargoToml cargoLock src extraArgs;
+            inherit cargoToml cargoLock src;
+            extraArgs = mergedExtraArgs;
             toolchain = cross.toolchain;
           };
           archiveAndHashLib = import ../archiveAndHash.nix;


### PR DESCRIPTION
- Add nativeBuildInputs parameter to build and default Nix expressions
- Merge buildInputs and nativeBuildInputs from both extraArgs and top-level arguments for cross builds
- Pass merged extraArgs to build.nix to ensure correct build environment setup