### PR TITLE
Fix Ollama streaming with HTTP implementation

### DIFF
--- a/mods/patches/ollama-streaming-fix.patch
+++ b/mods/patches/ollama-streaming-fix.patch
@@ -1,28 +1,275 @@
---- a/internal/ollama/ollama.go
-+++ b/internal/ollama/ollama.go
-@@ -119,6 +119,12 @@
+--- a/internal/ollama/ollama.go	2025-10-03 20:10:47
++++ b/internal/ollama/ollama.go	2025-10-04 17:19:29
+@@ -2,10 +2,16 @@
+ package ollama
+ 
+ import (
++	"bufio"
++	"bytes"
+ 	"context"
++	"encoding/json"
++	"fmt"
++	"io"
+ 	"net/http"
+ 	"net/url"
+ 	"strconv"
++	"strings"
+ 
+ 	"github.com/charmbracelet/mods/internal/proto"
+ 	"github.com/charmbracelet/mods/internal/stream"
+@@ -31,27 +37,101 @@
+ 
+ // Client ollama client.
+ type Client struct {
+-	*api.Client
++	baseURL string
++	http    *http.Client
+ }
+ 
+ // New creates a new [Client] with the given [Config].
+ func New(config Config) (*Client, error) {
+-	u, err := url.Parse(config.BaseURL)
++	_, err := url.Parse(config.BaseURL)
+ 	if err != nil {
+ 		return nil, err //nolint:wrapcheck
+ 	}
+-	client := api.NewClient(u, config.HTTPClient)
+ 	return &Client{
+-		Client: client,
++		baseURL: config.BaseURL,
++		http:    config.HTTPClient,
+ 	}, nil
+ }
+ 
++// HTTPChatStream mimics ssestream.Stream for Ollama
++type HTTPChatStream struct {
++	body     io.ReadCloser
++	scanner  *bufio.Scanner
++	current  api.ChatResponse
++	err      error
++	finished bool
++}
++
++func (h *HTTPChatStream) Next() bool {
++	if h.finished || h.err != nil {
++		return false
++	}
++
++	for h.scanner.Scan() {
++		line := strings.TrimSpace(h.scanner.Text())
++		if line == "" {
++			continue
++		}
++
++		var resp api.ChatResponse
++		if err := json.Unmarshal([]byte(line), &resp); err != nil {
++			h.err = err
++			return false
++		}
++
++		h.current = resp
++		return true
++	}
++
++	// Scanner finished
++	h.finished = true
++	if err := h.scanner.Err(); err != nil {
++		h.err = err
++	}
++	return false
++}
++
++func (h *HTTPChatStream) Current() api.ChatResponse {
++	return h.current
++}
++
++func (h *HTTPChatStream) Err() error {
++	return h.err
++}
++
++func (h *HTTPChatStream) Close() error {
++	if h.body != nil {
++		return h.body.Close()
++	}
++	return nil
++}
++
++// NewChatStream creates a new streaming chat request - like OpenAI's NewStreaming
++func (c *Client) NewChatStream(ctx context.Context, req api.ChatRequest) *HTTPChatStream {
++	jsonBody, _ := json.Marshal(req)
++	// DEBUG: Log the number of messages being sent
++	fmt.Printf("DEBUG: Sending %d messages to Ollama\n", len(req.Messages))
++	chatURL := strings.TrimSuffix(c.baseURL, "/") + "/api/chat"
++	httpReq, err := http.NewRequestWithContext(ctx, "POST", chatURL, bytes.NewBuffer(jsonBody))
++	if err != nil {
++		return &HTTPChatStream{err: err, finished: true}
++	}
++	httpReq.Header.Set("Content-Type", "application/json")
++
++	resp, err := c.http.Do(httpReq)
++	if err != nil {
++		return &HTTPChatStream{err: err, finished: true}
++	}
++
++	return &HTTPChatStream{
++		body:    resp.Body,
++		scanner: bufio.NewScanner(resp.Body),
++	}
++}
++
+ // Request implements stream.Client.
+ func (c *Client) Request(ctx context.Context, request proto.Request) stream.Stream {
+ 	b := true
+-	s := &Stream{
+-		toolCall: request.ToolCaller,
+-	}
+ 	body := api.ChatRequest{
+ 		Model:    request.Model,
+ 		Messages: fromProtoMessages(request.Messages),
+@@ -72,39 +152,42 @@
+ 	if request.TopP != nil {
+ 		body.Options["top_p"] = *request.TopP
+ 	}
+-	s.request = body
+-	s.messages = request.Messages
+-	s.factory = func() {
+-		s.done = false
+-		s.err = nil
+-		s.respCh = make(chan api.ChatResponse)
+-		go func() {
+-			if err := c.Chat(ctx, &s.request, s.fn); err != nil {
+-				s.err = err
+-			}
+-		}()
++
++	s := &Stream{
++		stream:   c.NewChatStream(ctx, body),
++		request:  body,
++		toolCall: request.ToolCaller,
++		messages: request.Messages,
++		ctx:      ctx,
++		client:   c,
+ 	}
+-	s.factory()
++	s.factory = func() *HTTPChatStream {
++		// Create fresh request with current conversation state
++		freshReq := api.ChatRequest{
++			Model:    body.Model,
++			Messages: fromProtoMessages(s.messages),
++			Stream:   body.Stream,
++			Tools:    body.Tools,
++			Options:  body.Options,
++		}
++		return c.NewChatStream(ctx, freshReq)
++	}
+ 	return s
+ }
+ 
+-// Stream ollama stream.
++// Stream ollama stream - EXACTLY like OpenAI structure  
+ type Stream struct {
+-	request  api.ChatRequest
+-	err      error
+ 	done     bool
+-	factory  func()
+-	respCh   chan api.ChatResponse
++	request  api.ChatRequest
++	stream   *HTTPChatStream
++	factory  func() *HTTPChatStream
+ 	message  api.Message
+-	toolCall func(name string, data []byte) (string, error)
+ 	messages []proto.Message
++	toolCall func(name string, data []byte) (string, error)
++	ctx      context.Context
++	client   *Client
+ }
+ 
+-func (s *Stream) fn(resp api.ChatResponse) error {
+-	s.respCh <- resp
+-	return nil
+-}
+-
+ // CallTools implements stream.Stream.
+ func (s *Stream) CallTools() []proto.ToolCallStatus {
+ 	statuses := make([]proto.ToolCallStatus, 0, len(s.message.ToolCalls))
+@@ -115,55 +198,46 @@
+ 			[]byte(call.Function.Arguments.String()),
+ 			s.toolCall,
+ 		)
+-		s.request.Messages = append(s.request.Messages, fromProtoMessage(msg))
  		s.messages = append(s.messages, msg)
  		statuses = append(statuses, status)
  	}
-+	// After executing tools, restart stream so AI can respond to tool results
-+	if len(s.message.ToolCalls) > 0 {
-+		s.done = false
-+		s.factory()
-+		s.message = api.Message{}
-+	}
  	return statuses
  }
  
-@@ -159,11 +165,9 @@
- 		return false
- 	}
- 	if s.done {
--		s.done = false
--		s.factory()
- 		s.messages = append(s.messages, toProtoMessage(s.message))
- 		s.request.Messages = append(s.request.Messages, s.message)
--		s.message = api.Message{}
-+		return false
- 	}
- 	return true
+-// Close implements stream.Stream.
+-func (s *Stream) Close() error {
+-	close(s.respCh)
+-	s.done = true
+-	return nil
+-}
++// Close implements stream.Stream - EXACTLY like OpenAI
++func (s *Stream) Close() error { return s.stream.Close() }
+ 
+-// Current implements stream.Stream.
++// Current implements stream.Stream - EXACTLY like OpenAI pattern
+ func (s *Stream) Current() (proto.Chunk, error) {
+-	select {
+-	case resp := <-s.respCh:
+-		chunk := proto.Chunk{
+-			Content: resp.Message.Content,
+-		}
+-		s.message.Content += resp.Message.Content
+-		s.message.ToolCalls = append(s.message.ToolCalls, resp.Message.ToolCalls...)
+-		if resp.Done {
+-			s.done = true
+-		}
+-		return chunk, nil
+-	default:
+-		return proto.Chunk{}, stream.ErrNoContent
+-	}
++	event := s.stream.Current()
++	s.message.Content += event.Message.Content
++	s.message.ToolCalls = append(s.message.ToolCalls, event.Message.ToolCalls...)
++	// Don't set s.done here - let the HTTP stream naturally finish
++	return proto.Chunk{
++		Content: event.Message.Content,
++	}, nil
  }
+ 
+-// Err implements stream.Stream.
+-func (s *Stream) Err() error { return s.err }
++// Err implements stream.Stream - EXACTLY like OpenAI
++func (s *Stream) Err() error { return s.stream.Err() }
+ 
+ // Messages implements stream.Stream.
+ func (s *Stream) Messages() []proto.Message { return s.messages }
+ 
+-// Next implements stream.Stream.
++// Next implements stream.Stream - EXACTLY like OpenAI
+ func (s *Stream) Next() bool {
+-	if s.err != nil {
+-		return false
+-	}
+ 	if s.done {
+ 		s.done = false
+-		s.factory()
+-		s.messages = append(s.messages, toProtoMessage(s.message))
+-		s.request.Messages = append(s.request.Messages, s.message)
++		s.stream = s.factory()
+ 		s.message = api.Message{}
+ 	}
+-	return true
+-}
++
++	if s.stream.Next() {
++		return true
++	}
++
++	s.done = true
++	s.messages = append(s.messages, toProtoMessage(s.message))
++
++	return false
++}
+\ No newline at end of file

--- a/mods/patches/ollama-streaming-fix.patch
+++ b/mods/patches/ollama-streaming-fix.patch
@@ -1,6 +1,6 @@
 --- a/internal/ollama/ollama.go	2025-10-03 20:10:47
-+++ b/internal/ollama/ollama.go	2025-10-04 17:19:29
-@@ -2,10 +2,16 @@
++++ b/internal/ollama/ollama.go	2025-10-04 17:59:01
+@@ -2,10 +2,15 @@
  package ollama
  
  import (
@@ -8,7 +8,6 @@
 +	"bytes"
  	"context"
 +	"encoding/json"
-+	"fmt"
 +	"io"
  	"net/http"
  	"net/url"
@@ -17,7 +16,7 @@
  
  	"github.com/charmbracelet/mods/internal/proto"
  	"github.com/charmbracelet/mods/internal/stream"
-@@ -31,27 +37,101 @@
+@@ -31,27 +36,99 @@
  
  // Client ollama client.
  type Client struct {
@@ -94,11 +93,9 @@
 +	return nil
 +}
 +
-+// NewChatStream creates a new streaming chat request - like OpenAI's NewStreaming
++// NewChatStream creates a new streaming chat request.
 +func (c *Client) NewChatStream(ctx context.Context, req api.ChatRequest) *HTTPChatStream {
 +	jsonBody, _ := json.Marshal(req)
-+	// DEBUG: Log the number of messages being sent
-+	fmt.Printf("DEBUG: Sending %d messages to Ollama\n", len(req.Messages))
 +	chatURL := strings.TrimSuffix(c.baseURL, "/") + "/api/chat"
 +	httpReq, err := http.NewRequestWithContext(ctx, "POST", chatURL, bytes.NewBuffer(jsonBody))
 +	if err != nil {
@@ -126,7 +123,7 @@
  	body := api.ChatRequest{
  		Model:    request.Model,
  		Messages: fromProtoMessages(request.Messages),
-@@ -72,39 +152,42 @@
+@@ -72,39 +149,41 @@
  	if request.TopP != nil {
  		body.Options["top_p"] = *request.TopP
  	}
@@ -152,7 +149,6 @@
  	}
 -	s.factory()
 +	s.factory = func() *HTTPChatStream {
-+		// Create fresh request with current conversation state
 +		freshReq := api.ChatRequest{
 +			Model:    body.Model,
 +			Messages: fromProtoMessages(s.messages),
@@ -165,8 +161,7 @@
  	return s
  }
  
--// Stream ollama stream.
-+// Stream ollama stream - EXACTLY like OpenAI structure  
+ // Stream ollama stream.
  type Stream struct {
 -	request  api.ChatRequest
 -	err      error
@@ -192,28 +187,18 @@
  // CallTools implements stream.Stream.
  func (s *Stream) CallTools() []proto.ToolCallStatus {
  	statuses := make([]proto.ToolCallStatus, 0, len(s.message.ToolCalls))
-@@ -115,55 +198,46 @@
- 			[]byte(call.Function.Arguments.String()),
- 			s.toolCall,
- 		)
--		s.request.Messages = append(s.request.Messages, fromProtoMessage(msg))
- 		s.messages = append(s.messages, msg)
- 		statuses = append(statuses, status)
- 	}
- 	return statuses
+@@ -123,47 +202,38 @@
  }
  
--// Close implements stream.Stream.
+ // Close implements stream.Stream.
 -func (s *Stream) Close() error {
 -	close(s.respCh)
 -	s.done = true
 -	return nil
 -}
-+// Close implements stream.Stream - EXACTLY like OpenAI
 +func (s *Stream) Close() error { return s.stream.Close() }
  
--// Current implements stream.Stream.
-+// Current implements stream.Stream - EXACTLY like OpenAI pattern
+ // Current implements stream.Stream.
  func (s *Stream) Current() (proto.Chunk, error) {
 -	select {
 -	case resp := <-s.respCh:
@@ -232,22 +217,19 @@
 +	event := s.stream.Current()
 +	s.message.Content += event.Message.Content
 +	s.message.ToolCalls = append(s.message.ToolCalls, event.Message.ToolCalls...)
-+	// Don't set s.done here - let the HTTP stream naturally finish
 +	return proto.Chunk{
 +		Content: event.Message.Content,
 +	}, nil
  }
  
--// Err implements stream.Stream.
+ // Err implements stream.Stream.
 -func (s *Stream) Err() error { return s.err }
-+// Err implements stream.Stream - EXACTLY like OpenAI
 +func (s *Stream) Err() error { return s.stream.Err() }
  
  // Messages implements stream.Stream.
  func (s *Stream) Messages() []proto.Message { return s.messages }
  
--// Next implements stream.Stream.
-+// Next implements stream.Stream - EXACTLY like OpenAI
+ // Next implements stream.Stream.
  func (s *Stream) Next() bool {
 -	if s.err != nil {
 -		return false


### PR DESCRIPTION
## Summary
- Replace broken channel-based streaming with HTTP client implementation
- Fix conversation state bleeding between model sessions
- Preserve tool execution and context preservation functionality
- Follow OpenAI/Anthropic streaming patterns

## Test plan
- [x] Build succeeds with new implementation
- [x] Context bleeding between sessions resolved
- [x] Tool calling mechanism works across all models
- [x] Tool result processing functions correctly
- [x] Conversation continuity maintained
- [x] No infinite loops or hanging requests