### PR TITLE
feat(rustnix): add workspaceMember param for Cargo workspace support

### DIFF
--- a/rustnix/lib/rust/build.nix
+++ b/rustnix/lib/rust/build.nix
@@ -2,12 +2,23 @@
   cargoLock,
   cargoToml,
   extraArgs ? {},
+  workspaceMember ? null,
   pkgs,
   src,
   toolchain,
 }: let
-  pname = cargoToml.package.name;
-  inherit (cargoToml.package) version;
+  pname =
+    if workspaceMember != null
+    then workspaceMember
+    else cargoToml.package.name;
+  version =
+    if cargoToml ? package
+    then cargoToml.package.version
+    else cargoToml.workspace.package.version;
+  cargoBuildFlags =
+    if workspaceMember != null
+    then ["-p" workspaceMember]
+    else [];
 
   drv =
     (pkgs.makeRustPlatform {
@@ -19,6 +30,7 @@
           version
           src
           cargoLock
+          cargoBuildFlags
           ;
         buildInputs = extraArgs.buildInputs or [];
         nativeBuildInputs = extraArgs.nativeBuildInputs or [];

--- a/rustnix/lib/rust/default.nix
+++ b/rustnix/lib/rust/default.nix
@@ -135,6 +135,7 @@
     nixpkgs,
     overlays,
     packageName ? null,
+    workspaceMember ? null,
     pkgs,
     src,
     system,
@@ -158,7 +159,7 @@
         };
 
       binaryPackage = cross.callPackage ./build.nix {
-        inherit cargoToml cargoLock src;
+        inherit cargoToml cargoLock src workspaceMember;
         extraArgs = mergedExtraArgs;
         inherit (cross) toolchain;
       };
@@ -167,7 +168,10 @@
       distributionBundle = archiveAndHashLib {
         inherit pkgs;
         drv = binaryPackage;
-        inherit (cargoToml.package) name;
+        name =
+          if workspaceMember != null
+          then workspaceMember
+          else cargoToml.package.name;
       };
 
       mainPackage =
@@ -179,7 +183,7 @@
         if installData != null && installData ? ${system}
         then
           pkgs.callPackage ./install.nix {
-            inherit cargoToml;
+            inherit cargoToml workspaceMember;
             data = installData.${system};
           }
         else mainPackage;

--- a/rustnix/lib/rust/install.nix
+++ b/rustnix/lib/rust/install.nix
@@ -1,11 +1,18 @@
 {
   cargoToml,
   data,
+  workspaceMember ? null,
   pkgs,
 }:
 pkgs.stdenvNoCC.mkDerivation rec {
-  pname = cargoToml.package.name;
-  inherit (cargoToml.package) version;
+  pname =
+    if workspaceMember != null
+    then workspaceMember
+    else cargoToml.package.name;
+  version =
+    if cargoToml ? package
+    then cargoToml.package.version
+    else cargoToml.workspace.package.version;
 
   src = pkgs.fetchurl {
     inherit (data) url;


### PR DESCRIPTION
Adds an optional `workspaceMember` parameter to `buildTargetOutputs` (and the underlying `build.nix` / `install.nix`) so rustnix can build a specific crate from a Cargo workspace.

**Behavior:**
- `workspaceMember = null` (default) — identical to today: reads `cargoToml.package.name` / `cargoToml.package.version`
- `workspaceMember = "my_crate"` — uses that as `pname`, reads version from `cargoToml.workspace.package.version`, passes `-p my_crate` to cargo

**Changes:**
- `build.nix` — conditional pname/version resolution, `cargoBuildFlags`
- `default.nix` — threads `workspaceMember` into build + install callPackage, fixes archive naming
- `install.nix` — conditional pname/version resolution

Fully backward-compatible. No existing callers are affected.