### PR TITLE
fix: create libLLVM.dylib symlink in rustc component on Darwin

### DIFF
--- a/rustnix/lib/rust/default.nix
+++ b/rustnix/lib/rust/default.nix
@@ -18,6 +18,39 @@
         else {}
       ));
 
+  # fenix bug: on Darwin, rust-objcopy/rust-lld load `@rpath/libLLVM.dylib`
+  # relative to `@loader_path/../lib`, i.e. `$lib/rustlib/<triplet>/lib`, but the
+  # dylib only ships at `$out/lib/libLLVM.dylib`. The fenix `combine` (symlinkJoin)
+  # only materializes `$out/bin` and `librustc_driver-*`, so this must be fixed in
+  # the rustc component itself (rustc-unwrapped) before toolchain assembly.
+  rustcFor = system: let
+    p = fenix.packages.${system};
+    isDarwin = builtins.match ".*-darwin" system != null;
+    rustc =
+      if isDarwin
+      then p.stable.rustc-unwrapped
+      else p.stable.rustc;
+  in
+    if !isDarwin
+    then rustc
+    else
+      rustc.overrideAttrs (old: {
+        installPhase =
+          (old.installPhase or "")
+          + ''
+            if [ -d "$out/lib" ] && [ -e "$out/lib/libLLVM.dylib" ]; then
+              for tgt in "$out"/lib/rustlib/*; do
+                if [ -d "$tgt" ] && [ -e "$tgt/bin/rust-objcopy" ]; then
+                  mkdir -p "$tgt/lib"
+                  if [ ! -e "$tgt/lib/libLLVM.dylib" ]; then
+                    ln -s "$out/lib/libLLVM.dylib" "$tgt/lib/libLLVM.dylib"
+                  fi
+                fi
+              done
+            fi
+          '';
+      });
+
   mkToolchain = {
     system,
     targets ? [],
@@ -27,7 +60,7 @@
     fenixTarget = utils.getTarget {inherit system variant;};
     baseToolchain = [
       fenix.packages.${system}.stable.cargo
-      fenix.packages.${system}.stable.rustc
+      (rustcFor system)
       fenix.packages.${system}.targets.${fenixTarget}.stable.rust-std
     ];
     additionalStd = map (t: fenix.packages.${system}.targets.${t}.stable.rust-std) targets;
@@ -87,7 +120,7 @@
       combine (
         [
           stable.cargo
-          stable.rustc
+          (rustcFor system)
           targets.${fenixTarget}.stable.rust-std # Target-specific stdlib
         ]
         ++ (map (t: targets.${t}.stable.rust-std) additionalTargets)


### PR DESCRIPTION
Fixes the Darwin `rust-objcopy` SIGABRT caused by a missing `@rpath/libLLVM.dylib` (fenix issue nix-community/fenix#242).

**Root cause:** rust-objcopy loads `@rpath/libLLVM.dylib` relative to `@loader_path/../lib`, resolving to `rustlib/<triplet>/lib`, where the dylib never shipped (only `$out/lib/libLLVM.dylib` exists). Fenix `combine` (symlinkJoin) only materializes `$out/bin` and `librustc_driver-*`, so the fix must be applied to the unwrapped rustc component before toolchain assembly.

**Change** (`rustnix/lib/rust/default.nix`):
- Add `rustcFor system` helper. On Darwin it overrides the unwrapped rustc's `installPhase` to create `rustlib/<triplet>/lib/libLLVM.dylib → $out/lib/libLLVM.dylib` for each triplet shipping `rust-objcopy`. Non-Darwin systems are unchanged.
- Use `rustcFor` in both `mkToolchain` and `mkCrossPkgs`.

**Validation (aarch64-darwin):**
- `nix flake check` passes (3 checks).
- Built `packages.aarch64-darwin.toolchain`; verified the symlink exists in the rustc component.
- `rust-objcopy --version` → exit 0 (previously SIGABRT).
- `rust-objcopy --strip-all /bin/echo /tmp/out` → produces a valid stripped binary.